### PR TITLE
Add space after units

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -63,7 +63,7 @@ headerView = Vue.component('header-view',{
                 <span v-if="quantity.valueLL == 'novalue'" :style="{ fontStyle: 'italic' }">
                     {{ quantity.valueLabel }}</span><span v-else>{{ quantity.valueLabel }}
                 </span> 
-                {{quantity.unit}}( <a @click="removeQuantity(quantity)">&#x2715;</a> )
+                {{quantity.unit}}&nbsp;( <a @click="removeQuantity(quantity)">&#x2715;</a> )
             </p>
         </div>
     `,


### PR DESCRIPTION
Display of “quantity” filters is missing a space