### PR TITLE
Change color for Wikidata links

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -221,7 +221,7 @@ a:hover {
   background-color: #f1f0fe;
 }
 
-.wikiDataLink {
+.externalLink {
   color: #990000;
 }
 

--- a/css/index.css
+++ b/css/index.css
@@ -221,6 +221,10 @@ a:hover {
   background-color: #f1f0fe;
 }
 
+.wikiDataLink {
+  color: #990000;
+}
+
 @media screen and (max-width: 1200px) {
 	.dropdown-content {
 		column-count: 3;

--- a/src/components/view-all-items.js
+++ b/src/components/view-all-items.js
@@ -60,7 +60,7 @@ viewallitems = Vue.component('view-all-items', {
                 <div v-else>
                         <ul>
                             <li v-for="item in items">
-                                <a :href="linkToWikidata(item.value.value)">{{item.valueLabel.value}}</a>
+                                <a :href="linkToWikidata(item.value.value)" style="color:#990000">{{item.valueLabel.value}}</a>
                             </li>
                         </ul>
                 </div>

--- a/src/components/view-all-items.js
+++ b/src/components/view-all-items.js
@@ -60,7 +60,7 @@ viewallitems = Vue.component('view-all-items', {
                 <div v-else>
                         <ul>
                             <li v-for="item in items">
-                                <a :href="linkToWikidata(item.value.value)" style="color:#990000">{{item.valueLabel.value}}</a>
+                                <a :href="linkToWikidata(item.value.value)" class="wikiDataLink">{{item.valueLabel.value}}</a>
                             </li>
                         </ul>
                 </div>

--- a/src/components/view-all-items.js
+++ b/src/components/view-all-items.js
@@ -60,7 +60,7 @@ viewallitems = Vue.component('view-all-items', {
                 <div v-else>
                         <ul>
                             <li v-for="item in items">
-                                <a :href="linkToWikidata(item.value.value)" class="wikiDataLink">{{item.valueLabel.value}}</a>
+                                <a :href="linkToWikidata(item.value.value)" class="externalLink">{{item.valueLabel.value}}</a>
                             </li>
                         </ul>
                 </div>


### PR DESCRIPTION
Different display for internal vs. Wikidata links
Possible color for Wikidata links: #990000, which matches the red/maroon color in the Wikidata logo