### PR TITLE
Fix arrow direction in language selector

### DIFF
--- a/src/components/topnav.js
+++ b/src/components/topnav.js
@@ -88,7 +88,7 @@ topnav = Vue.component('top-nav', {
                 <div class="dropdown">
                     <button class="dropbtn" @click="toggleDropdown">{{ urlParams.get('lang')?urlParams.get('lang'): (defaultLanguages[0]?defaultLanguages[0]:'en') }} 
                         <span>
-                            <img v-bind:style="{ transform:'rotate('+ dropdownDisplay*180 + 'deg)' }" src="images/down-arrow.svg" height="14px"/>
+                            <img src="images/down-arrow.svg" height="14px"/>
                         </span>
                     </button>
                     <div class="dropdown-content" v-bind:style="{ display: (dropdownDisplay?'block':'none') }">


### PR DESCRIPTION
Change arrow in language selector to always point down, even after click