### PR TITLE
Restructure itemCount translation message for "nl"

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -1,5 +1,5 @@
 {
-    "itemCount": "There {{PLURAL:$1|is one item that matches|are $1 items that match}} this description.",
+    "itemCount": "{{PLURAL:$1|There is one item that matches this description.|There are $1 items that match this description.}}",
     "classPlaceholder": "Enter class",
     "browse": "Or, browse any of the following classes:",
     "noFiltersDefined": "No filter is defined for this class.",

--- a/languages/en.json
+++ b/languages/en.json
@@ -1,5 +1,5 @@
 {
-    "itemCount": "{{PLURAL:$1|There is one item that matches this description.|There are $1 items that match this description.}}",
+    "itemCount": "There {{PLURAL:$1|is one item that matches|are $1 items that match}} this description.",
     "classPlaceholder": "Enter class",
     "browse": "Or, browse any of the following classes:",
     "noFiltersDefined": "No filter is defined for this class.",

--- a/languages/nl.json
+++ b/languages/nl.json
@@ -4,7 +4,7 @@
 			"McDutchie"
 		]
 	},
-	"itemCount": "Er {{PLURAL:$1|is één item dat|zijn $1 items die}} aan deze beschrijving voldoe{{PLURAL:$1|t|n}}.",
+	"itemCount": "{{PLURAL:$1|Er is één item dat aan deze beschrijving voldoet.|Er zijn $1 items die aan deze beschrijving voldoen.}}",
 	"classPlaceholder": "Geef een klasse op",
 	"browse": "Of blader door een van de volgende klassen:",
 	"noFiltersDefined": "Er is voor deze klasse geen filter gedefinieerd.",


### PR DESCRIPTION
For nl, a 2nd PLURAL tag within the “itemCount” message causes a strange display at the top - see [here](https://wikidatawalkabout.org/?c=Q15632617&lang=nl&cf=P1080)

Restructured the translation message for "nl" to meet the plural representation needs.