### PR TITLE
Fix Plural forms in slovenian

### DIFF
--- a/languages/sl.json
+++ b/languages/sl.json
@@ -4,7 +4,7 @@
 			"Eleassar"
 		]
 	},
-	"itemCount": "Temu opisu {{PLURAL:$1|ustreza en predmet|two=ustrezata dva predmeta|few=ustrezajo $1 predmeti|ustreza $1 predmetov}}.",
+	"itemCount": "Temu opisu {{PLURAL:$1|one=ustreza en predmet|two=ustrezata dva predmeta|few=ustrezajo $1 predmeti|ustreza $1 predmetov}}.",
 	"classPlaceholder": "Vnesite skupino",
 	"browse": "Ali prebrskajte katerega od naslednjih razredov:",
 	"noFiltersDefined": "Za ta razred ni opredeljen noben filter.",

--- a/src/components/filter-values.js
+++ b/src/components/filter-values.js
@@ -317,23 +317,23 @@ filtervalues = Vue.component('filter-values', {
                         return obj.includes(element)
                     });
                     if(pluralOne.length!==0){
-                        pluralMap[index.toString()] = pluralOne[0].replace(element, '')
+                        pluralMap[index] = pluralOne[0].replace(element, '')
                         pluralCopy = pluralCopy.filter((obj)=>{
                             return !obj.includes(element)
                         })
                     }
                 });
-                if(totalValues === 0 && Object.keys(pluralMap).includes('0')){
-                    str = pluralMap['0'];
-                } else if(totalValues === 1 && Object.keys(pluralMap).includes('1')){
-                    str = pluralMap['1'];
-                } else if(totalValues === 2 && Object.keys(pluralMap).includes('2')){
-                    str = pluralMap['2'];
+                if(totalValues === 0 && Object.keys(pluralMap).includes(0)){
+                    str = pluralMap[0];
+                } else if(totalValues === 1 && Object.keys(pluralMap).includes(1)){
+                    str = pluralMap[1];
+                } else if(totalValues === 2 && Object.keys(pluralMap).includes(2)){
+                    str = pluralMap[2];
                 } else if((totalValues >2 && totalValues <=6)
-                    && Object.keys(pluralMap).includes('3')){
-                    str = pluralMap['3'];
-                } else if(totalValues >6 && Object.keys(pluralMap).includes('4')){
-                    str = pluralMap['4'];
+                    && Object.keys(pluralMap).includes(3)){
+                    str = pluralMap[3];
+                } else if(totalValues >6 && Object.keys(pluralMap).includes(4)){
+                    str = pluralMap[4];
                 } else{
                     if(Object.keys(pluralMap).length === 0){
                         str = matches[1].split('|')[(totalValues > 1 ? 1 : 0)]

--- a/src/components/filter-values.js
+++ b/src/components/filter-values.js
@@ -308,7 +308,39 @@ filtervalues = Vue.component('filter-values', {
         displayPluralCount(message,totalValues){
             if(message){
                 matches = message.match('{{PLURAL:[\\s]*\\$1\\|(.*)}}')
-                str = matches[1].split('|')[(totalValues > 1 ? 1 : 0)]
+                pluralValues = matches[1].split("|")
+                pluralMap = {}
+                pluralConditions = ['zero=', 'one=', 'two=', 'few=', 'many=']
+                pluralCopy = [...pluralValues]
+                pluralConditions.forEach((element, index) => {
+                    pluralOne = pluralValues.filter((obj)=>{
+                        return obj.includes(element)
+                    });
+                    if(pluralOne.length!==0){
+                        pluralMap[index.toString()] = pluralOne[0].replace(element, '')
+                        pluralCopy = pluralCopy.filter((obj)=>{
+                            return !obj.includes(element)
+                        })
+                    }
+                });
+                if(totalValues === 0 && Object.keys(pluralMap).includes('0')){
+                    str = pluralMap['0'];
+                } else if(totalValues === 1 && Object.keys(pluralMap).includes('1')){
+                    str = pluralMap['1'];
+                } else if(totalValues === 2 && Object.keys(pluralMap).includes('2')){
+                    str = pluralMap['2'];
+                } else if((totalValues >2 && totalValues <=6)
+                    && Object.keys(pluralMap).includes('3')){
+                    str = pluralMap['3'];
+                } else if(totalValues >6 && Object.keys(pluralMap).includes('4')){
+                    str = pluralMap['4'];
+                } else{
+                    if(Object.keys(pluralMap).length === 0){
+                        str = matches[1].split('|')[(totalValues > 1 ? 1 : 0)]
+                    } else if(pluralCopy.length !== 0){
+                        str = pluralCopy[0];
+                    }
+                }
                 str = str.replace("$1", (totalValues < 1000000 ? numberWithCommas(totalValues) : '1 million +'))
                 return message.replace(/{{PLURAL:[\s]*\$1\|(.*)}}/g,str)
             }

--- a/src/components/filters-view.js
+++ b/src/components/filters-view.js
@@ -40,7 +40,39 @@ filtersview = Vue.component('filters-view', {
         displayPluralCount(message,totalValues) {
             if(message){
                 matches = message.match('{{PLURAL:[\\s]*\\$1\\|(.*)}}')
-                str = matches[1].split('|')[(totalValues > 1 ? 1 : 0)]
+                pluralValues = matches[1].split("|")
+                pluralMap = {}
+                pluralConditions = ['zero=', 'one=', 'two=', 'few=', 'many=']
+                pluralCopy = [...pluralValues]
+                pluralConditions.forEach((element, index) => {
+                    pluralOne = pluralValues.filter((obj)=>{
+                        return obj.includes(element)
+                    });
+                    if(pluralOne.length!==0){
+                        pluralMap[index.toString()] = pluralOne[0].replace(element, '')
+                        pluralCopy = pluralCopy.filter((obj)=>{
+                            return !obj.includes(element)
+                        })
+                    }
+                });
+                if(totalValues === 0 && Object.keys(pluralMap).includes('0')){
+                    str = pluralMap['0'];
+                } else if(totalValues === 1 && Object.keys(pluralMap).includes('1')){
+                    str = pluralMap['1'];
+                } else if(totalValues === 2 && Object.keys(pluralMap).includes('2')){
+                    str = pluralMap['2'];
+                } else if((totalValues >2 && totalValues <=6)
+                    && Object.keys(pluralMap).includes('3')){
+                    str = pluralMap['3'];
+                } else if(totalValues >6 && Object.keys(pluralMap).includes('4')){
+                    str = pluralMap['4'];
+                } else{
+                    if(Object.keys(pluralMap).length === 0){
+                        str = matches[1].split('|')[(totalValues > 1 ? 1 : 0)]
+                    } else if(pluralCopy.length !== 0){
+                        str = pluralCopy[0];
+                    }
+                }
                 str = str.replace("$1", "<b>" + (totalValues < 1000000 ? numberWithCommas(totalValues) : '1 million +') + "</b>")
                 return message.replace(/{{PLURAL:[\s]*\$1\|(.*)}}/g, str)
             }

--- a/src/components/filters-view.js
+++ b/src/components/filters-view.js
@@ -49,23 +49,23 @@ filtersview = Vue.component('filters-view', {
                         return obj.includes(element)
                     });
                     if(pluralOne.length!==0){
-                        pluralMap[index.toString()] = pluralOne[0].replace(element, '')
+                        pluralMap[index] = pluralOne[0].replace(element, '')
                         pluralCopy = pluralCopy.filter((obj)=>{
                             return !obj.includes(element)
                         })
                     }
                 });
-                if(totalValues === 0 && Object.keys(pluralMap).includes('0')){
-                    str = pluralMap['0'];
-                } else if(totalValues === 1 && Object.keys(pluralMap).includes('1')){
-                    str = pluralMap['1'];
-                } else if(totalValues === 2 && Object.keys(pluralMap).includes('2')){
-                    str = pluralMap['2'];
+                if(totalValues === 0 && Object.keys(pluralMap).includes(0)){
+                    str = pluralMap[0];
+                } else if(totalValues === 1 && Object.keys(pluralMap).includes(1)){
+                    str = pluralMap[1];
+                } else if(totalValues === 2 && Object.keys(pluralMap).includes(2)){
+                    str = pluralMap[2];
                 } else if((totalValues >2 && totalValues <=6)
-                    && Object.keys(pluralMap).includes('3')){
-                    str = pluralMap['3'];
-                } else if(totalValues >6 && Object.keys(pluralMap).includes('4')){
-                    str = pluralMap['4'];
+                    && Object.keys(pluralMap).includes(3)){
+                    str = pluralMap[3];
+                } else if(totalValues >6 && Object.keys(pluralMap).includes(4)){
+                    str = pluralMap[4];
                 } else{
                     if(Object.keys(pluralMap).length === 0){
                         str = matches[1].split('|')[(totalValues > 1 ? 1 : 0)]

--- a/src/components/secondary-filter-values.js
+++ b/src/components/secondary-filter-values.js
@@ -197,23 +197,23 @@ secondayFilterValues = Vue.component('secondary-filters', {
                         return obj.includes(element)
                     });
                     if(pluralOne.length!==0){
-                        pluralMap[index.toString()] = pluralOne[0].replace(element, '')
+                        pluralMap[index] = pluralOne[0].replace(element, '')
                         pluralCopy = pluralCopy.filter((obj)=>{
                             return !obj.includes(element)
                         })
                     }
                 });
-                if(totalValues === 0 && Object.keys(pluralMap).includes('0')){
-                    str = pluralMap['0'];
-                } else if(totalValues === 1 && Object.keys(pluralMap).includes('1')){
-                    str = pluralMap['1'];
-                } else if(totalValues === 2 && Object.keys(pluralMap).includes('2')){
-                    str = pluralMap['2'];
+                if(totalValues === 0 && Object.keys(pluralMap).includes(0)){
+                    str = pluralMap[0];
+                } else if(totalValues === 1 && Object.keys(pluralMap).includes(1)){
+                    str = pluralMap[1];
+                } else if(totalValues === 2 && Object.keys(pluralMap).includes(2)){
+                    str = pluralMap[2];
                 } else if((totalValues >2 && totalValues <=6)
-                    && Object.keys(pluralMap).includes('3')){
-                    str = pluralMap['3'];
-                } else if(totalValues >6 && Object.keys(pluralMap).includes('4')){
-                    str = pluralMap['4'];
+                    && Object.keys(pluralMap).includes(3)){
+                    str = pluralMap[3];
+                } else if(totalValues >6 && Object.keys(pluralMap).includes(4)){
+                    str = pluralMap[4];
                 } else{
                     if(Object.keys(pluralMap).length === 0){
                         str = matches[1].split('|')[(totalValues > 1 ? 1 : 0)]

--- a/src/components/secondary-filter-values.js
+++ b/src/components/secondary-filter-values.js
@@ -188,7 +188,39 @@ secondayFilterValues = Vue.component('secondary-filters', {
         displayPluralCount(message, totalValues) {
             if(message){
                 matches = message.match('{{PLURAL:[\\s]*\\$1\\|(.*)}}')
-                str = matches[1].split('|')[(totalValues > 1 ? 1 : 0)]
+                pluralValues = matches[1].split("|")
+                pluralMap = {}
+                pluralConditions = ['zero=', 'one=', 'two=', 'few=', 'many=']
+                pluralCopy = [...pluralValues]
+                pluralConditions.forEach((element, index) => {
+                    pluralOne = pluralValues.filter((obj)=>{
+                        return obj.includes(element)
+                    });
+                    if(pluralOne.length!==0){
+                        pluralMap[index.toString()] = pluralOne[0].replace(element, '')
+                        pluralCopy = pluralCopy.filter((obj)=>{
+                            return !obj.includes(element)
+                        })
+                    }
+                });
+                if(totalValues === 0 && Object.keys(pluralMap).includes('0')){
+                    str = pluralMap['0'];
+                } else if(totalValues === 1 && Object.keys(pluralMap).includes('1')){
+                    str = pluralMap['1'];
+                } else if(totalValues === 2 && Object.keys(pluralMap).includes('2')){
+                    str = pluralMap['2'];
+                } else if((totalValues >2 && totalValues <=6)
+                    && Object.keys(pluralMap).includes('3')){
+                    str = pluralMap['3'];
+                } else if(totalValues >6 && Object.keys(pluralMap).includes('4')){
+                    str = pluralMap['4'];
+                } else{
+                    if(Object.keys(pluralMap).length === 0){
+                        str = matches[1].split('|')[(totalValues > 1 ? 1 : 0)]
+                    } else if(pluralCopy.length !== 0){
+                        str = pluralCopy[0];
+                    }
+                }
                 str = str.replace("$1", (totalValues < 1000000 ? numberWithCommas(totalValues) : '1 million +'))
                 return message.replace(/{{PLURAL:[\s]*\$1\|(.*)}}/g, str)
             }

--- a/src/components/subclass.js
+++ b/src/components/subclass.js
@@ -84,7 +84,39 @@ subclass = Vue.component('subclass-view', {
             if(message){
 
                 matches = message.match('{{PLURAL:[\\s]*\\$1\\|(.*)}}')
-                str = matches[1].split('|')[(totalValues > 1 ? 1 : 0)]
+                pluralValues = matches[1].split("|")
+                pluralMap = {}
+                pluralConditions = ['zero=', 'one=', 'two=', 'few=', 'many=']
+                pluralCopy = [...pluralValues]
+                pluralConditions.forEach((element, index) => {
+                    pluralOne = pluralValues.filter((obj)=>{
+                        return obj.includes(element)
+                    });
+                    if(pluralOne.length!==0){
+                        pluralMap[index.toString()] = pluralOne[0].replace(element, '')
+                        pluralCopy = pluralCopy.filter((obj)=>{
+                            return !obj.includes(element)
+                        })
+                    }
+                });
+                if(totalValues === 0 && Object.keys(pluralMap).includes('0')){
+                    str = pluralMap['0'];
+                } else if(totalValues === 1 && Object.keys(pluralMap).includes('1')){
+                    str = pluralMap['1'];
+                } else if(totalValues === 2 && Object.keys(pluralMap).includes('2')){
+                    str = pluralMap['2'];
+                } else if((totalValues >2 && totalValues <=6)
+                    && Object.keys(pluralMap).includes('3')){
+                    str = pluralMap['3'];
+                } else if(totalValues >6 && Object.keys(pluralMap).includes('4')){
+                    str = pluralMap['4'];
+                } else{
+                    if(Object.keys(pluralMap).length === 0){
+                        str = matches[1].split('|')[(totalValues > 1 ? 1 : 0)]
+                    } else if(pluralCopy.length !== 0){
+                        str = pluralCopy[0];
+                    }
+                }
                 str = str.replace("$1", (totalValues < 1000000 ? numberWithCommas(totalValues) : '1 million +'))
                 return message.replace(/{{PLURAL:[\s]*\$1\|(.*)}}/g, str)
             }

--- a/src/components/subclass.js
+++ b/src/components/subclass.js
@@ -93,23 +93,23 @@ subclass = Vue.component('subclass-view', {
                         return obj.includes(element)
                     });
                     if(pluralOne.length!==0){
-                        pluralMap[index.toString()] = pluralOne[0].replace(element, '')
+                        pluralMap[index] = pluralOne[0].replace(element, '')
                         pluralCopy = pluralCopy.filter((obj)=>{
                             return !obj.includes(element)
                         })
                     }
                 });
-                if(totalValues === 0 && Object.keys(pluralMap).includes('0')){
-                    str = pluralMap['0'];
-                } else if(totalValues === 1 && Object.keys(pluralMap).includes('1')){
-                    str = pluralMap['1'];
-                } else if(totalValues === 2 && Object.keys(pluralMap).includes('2')){
-                    str = pluralMap['2'];
+                if(totalValues === 0 && Object.keys(pluralMap).includes(0)){
+                    str = pluralMap[0];
+                } else if(totalValues === 1 && Object.keys(pluralMap).includes(1)){
+                    str = pluralMap[1];
+                } else if(totalValues === 2 && Object.keys(pluralMap).includes(2)){
+                    str = pluralMap[2];
                 } else if((totalValues >2 && totalValues <=6)
-                    && Object.keys(pluralMap).includes('3')){
-                    str = pluralMap['3'];
-                } else if(totalValues >6 && Object.keys(pluralMap).includes('4')){
-                    str = pluralMap['4'];
+                    && Object.keys(pluralMap).includes(3)){
+                    str = pluralMap[3];
+                } else if(totalValues >6 && Object.keys(pluralMap).includes(4)){
+                    str = pluralMap[4];
                 } else{
                     if(Object.keys(pluralMap).length === 0){
                         str = matches[1].split('|')[(totalValues > 1 ? 1 : 0)]

--- a/src/components/superclass.js
+++ b/src/components/superclass.js
@@ -83,7 +83,39 @@ superclass = Vue.component('superclass-view', {
         displayPluralCount(message, totalValues) {
             if(message){
                 matches = message.match('{{PLURAL:[\\s]*\\$1\\|(.*)}}')
-                str = matches[1].split('|')[(totalValues > 1 ? 1 : 0)]
+                pluralValues = matches[1].split("|")
+                pluralMap = {}
+                pluralConditions = ['zero=', 'one=', 'two=', 'few=', 'many=']
+                pluralCopy = [...pluralValues]
+                pluralConditions.forEach((element, index) => {
+                    pluralOne = pluralValues.filter((obj)=>{
+                        return obj.includes(element)
+                    });
+                    if(pluralOne.length!==0){
+                        pluralMap[index.toString()] = pluralOne[0].replace(element, '')
+                        pluralCopy = pluralCopy.filter((obj)=>{
+                            return !obj.includes(element)
+                        })
+                    }
+                });
+                if(totalValues === 0 && Object.keys(pluralMap).includes('0')){
+                    str = pluralMap['0'];
+                } else if(totalValues === 1 && Object.keys(pluralMap).includes('1')){
+                    str = pluralMap['1'];
+                } else if(totalValues === 2 && Object.keys(pluralMap).includes('2')){
+                    str = pluralMap['2'];
+                } else if((totalValues >2 && totalValues <=6)
+                    && Object.keys(pluralMap).includes('3')){
+                    str = pluralMap['3'];
+                } else if(totalValues >6 && Object.keys(pluralMap).includes('4')){
+                    str = pluralMap['4'];
+                } else{
+                    if(Object.keys(pluralMap).length === 0){
+                        str = matches[1].split('|')[(totalValues > 1 ? 1 : 0)]
+                    } else if(pluralCopy.length !== 0){
+                        str = pluralCopy[0];
+                    }
+                }
                 str = str.replace("$1", (totalValues < 1000000 ? numberWithCommas(totalValues) : '1 million +'))
                 return message.replace(/{{PLURAL:[\s]*\$1\|(.*)}}/g, str)
             }

--- a/src/components/superclass.js
+++ b/src/components/superclass.js
@@ -92,23 +92,23 @@ superclass = Vue.component('superclass-view', {
                         return obj.includes(element)
                     });
                     if(pluralOne.length!==0){
-                        pluralMap[index.toString()] = pluralOne[0].replace(element, '')
+                        pluralMap[index] = pluralOne[0].replace(element, '')
                         pluralCopy = pluralCopy.filter((obj)=>{
                             return !obj.includes(element)
                         })
                     }
                 });
-                if(totalValues === 0 && Object.keys(pluralMap).includes('0')){
-                    str = pluralMap['0'];
-                } else if(totalValues === 1 && Object.keys(pluralMap).includes('1')){
-                    str = pluralMap['1'];
-                } else if(totalValues === 2 && Object.keys(pluralMap).includes('2')){
-                    str = pluralMap['2'];
+                if(totalValues === 0 && Object.keys(pluralMap).includes(0)){
+                    str = pluralMap[0];
+                } else if(totalValues === 1 && Object.keys(pluralMap).includes(1)){
+                    str = pluralMap[1];
+                } else if(totalValues === 2 && Object.keys(pluralMap).includes(2)){
+                    str = pluralMap[2];
                 } else if((totalValues >2 && totalValues <=6)
-                    && Object.keys(pluralMap).includes('3')){
-                    str = pluralMap['3'];
-                } else if(totalValues >6 && Object.keys(pluralMap).includes('4')){
-                    str = pluralMap['4'];
+                    && Object.keys(pluralMap).includes(3)){
+                    str = pluralMap[3];
+                } else if(totalValues >6 && Object.keys(pluralMap).includes(4)){
+                    str = pluralMap[4];
                 } else{
                     if(Object.keys(pluralMap).length === 0){
                         str = matches[1].split('|')[(totalValues > 1 ? 1 : 0)]

--- a/src/components/view-all-items.js
+++ b/src/components/view-all-items.js
@@ -161,23 +161,23 @@ viewallitems = Vue.component('view-all-items', {
                         return obj.includes(element)
                     });
                     if(pluralOne.length!==0){
-                        pluralMap[index.toString()] = pluralOne[0].replace(element, '')
+                        pluralMap[index] = pluralOne[0].replace(element, '')
                         pluralCopy = pluralCopy.filter((obj)=>{
                             return !obj.includes(element)
                         })
                     }
                 });
-                if(totalValues === 0 && Object.keys(pluralMap).includes('0')){
-                    str = pluralMap['0'];
-                } else if(totalValues === 1 && Object.keys(pluralMap).includes('1')){
-                    str = pluralMap['1'];
-                } else if(totalValues === 2 && Object.keys(pluralMap).includes('2')){
-                    str = pluralMap['2'];
+                if(totalValues === 0 && Object.keys(pluralMap).includes(0)){
+                    str = pluralMap[0];
+                } else if(totalValues === 1 && Object.keys(pluralMap).includes(1)){
+                    str = pluralMap[1];
+                } else if(totalValues === 2 && Object.keys(pluralMap).includes(2)){
+                    str = pluralMap[2];
                 } else if((totalValues >2 && totalValues <=6)
-                    && Object.keys(pluralMap).includes('3')){
-                    str = pluralMap['3'];
-                } else if(totalValues >6 && Object.keys(pluralMap).includes('4')){
-                    str = pluralMap['4'];
+                    && Object.keys(pluralMap).includes(3)){
+                    str = pluralMap[3];
+                } else if(totalValues >6 && Object.keys(pluralMap).includes(4)){
+                    str = pluralMap[4];
                 } else{
                     if(Object.keys(pluralMap).length === 0){
                         str = matches[1].split('|')[(totalValues > 1 ? 1 : 0)]

--- a/src/components/view-all-items.js
+++ b/src/components/view-all-items.js
@@ -152,7 +152,39 @@ viewallitems = Vue.component('view-all-items', {
                  either the first or second half based on number of values.
                 */  
                 matches = message.match('{{PLURAL:[\\s]*\\$1\\|(.*)}}')
-                str = matches[1].split('|')[(totalValues > 1 ? 1 : 0)]
+                pluralValues = matches[1].split("|")
+                pluralMap = {}
+                pluralConditions = ['zero=', 'one=', 'two=', 'few=', 'many=']
+                pluralCopy = [...pluralValues]
+                pluralConditions.forEach((element, index) => {
+                    pluralOne = pluralValues.filter((obj)=>{
+                        return obj.includes(element)
+                    });
+                    if(pluralOne.length!==0){
+                        pluralMap[index.toString()] = pluralOne[0].replace(element, '')
+                        pluralCopy = pluralCopy.filter((obj)=>{
+                            return !obj.includes(element)
+                        })
+                    }
+                });
+                if(totalValues === 0 && Object.keys(pluralMap).includes('0')){
+                    str = pluralMap['0'];
+                } else if(totalValues === 1 && Object.keys(pluralMap).includes('1')){
+                    str = pluralMap['1'];
+                } else if(totalValues === 2 && Object.keys(pluralMap).includes('2')){
+                    str = pluralMap['2'];
+                } else if((totalValues >2 && totalValues <=6)
+                    && Object.keys(pluralMap).includes('3')){
+                    str = pluralMap['3'];
+                } else if(totalValues >6 && Object.keys(pluralMap).includes('4')){
+                    str = pluralMap['4'];
+                } else{
+                    if(Object.keys(pluralMap).length === 0){
+                        str = matches[1].split('|')[(totalValues > 1 ? 1 : 0)]
+                    } else if(pluralCopy.length !== 0){
+                        str = pluralCopy[0];
+                    }
+                }
                 str = str.replace("$1", "<b>" + (totalValues < 1000000 ? numberWithCommas(totalValues) : '1 million +') + "</b>")
                 return message.replace(/{{PLURAL:[\s]*\$1\|(.*)}}/g, str)
             }


### PR DESCRIPTION
For sl, there is the use of the parameters “one”, “two” and “few”, which causes a bad display - see [here](https://wikidatawalkabout.org/?c=Q15632617&lang=sl&cf=P1080) 

Fixes #18 