### PR TITLE
Fix for hi and sk plural result

### DIFF
--- a/languages/hi.json
+++ b/languages/hi.json
@@ -24,7 +24,7 @@
 	"specificClass": "एक और विशिष्ट वर्ग में बदलें:",
 	"generalClass": "एक और साधारण वर्ग में बदलें:",
 	"viewList": "आयटमों की सूची देखें",
-	"results": "({{PLURAL:$1|$1 अंजाम}})",
+	"results": "($1 अंजाम)",
 	"applyLinkedFilter": "$1 पर फिल्टर लागू करें",
 	"chooseLinkedFilter": "इनमें से किसी एक वर्ग से फ़िल्टर चुनें:"
 }

--- a/languages/sk.json
+++ b/languages/sk.json
@@ -24,7 +24,7 @@
 	"specificClass": "Zmenia na viac špecifikovaný typ:",
 	"generalClass": "Zmena na viac všeobecný typ:",
 	"viewList": "Zobraziť zoznam položiek",
-	"results": "({{PLURAL:$1|počet výsledkov: $1 }})",
+	"results": "(počet výsledkov: $1 )",
 	"applyLinkedFilter": "Použiť filter na $1",
 	"chooseLinkedFilter": "Vybrať filter z jedného z nasledovných typov:"
 }


### PR DESCRIPTION
For hi and sk, there is only one string, instead of two, for some of the PLURAL tags, which causes results to not get displayed - see [here](https://wikidatawalkabout.org/?c=Q15632617&lang=hi&cf=P1080)